### PR TITLE
[Fix #8] UseAsTemplate-property in Model was always null

### DIFF
--- a/Ardoq/Models/Converters/ModelConverter.cs
+++ b/Ardoq/Models/Converters/ModelConverter.cs
@@ -11,17 +11,17 @@ namespace Ardoq.Models.Converters
 		public override object ReadJson (JsonReader reader, Type objectType, object existingValue,
 		                                 JsonSerializer serializer)
 		{
-			JObject jsonObject = JObject.Load (reader);
+			var jsonObject = JObject.Load (reader);
 
 			var result = (Model)base.ReadJson (jsonObject.CreateReader (), objectType, existingValue, serializer);
 			Console.WriteLine ("Parsing model: " + jsonObject.Property ("name"));
-			JProperty referenceTypesProperty = jsonObject.Property ("referenceTypes");
+			var referenceTypesProperty = jsonObject.Property ("referenceTypes");
 			if (referenceTypesProperty != null) {
 				var referenceTypesDictionary = referenceTypesProperty.Value.ToObject<Dictionary<int, JObject>> ();
 				result.ReferenceTypes = GetReferenceTypes (referenceTypesDictionary);
 			}
 
-			JProperty rootProperty = jsonObject.Property ("root");
+			var rootProperty = jsonObject.Property ("root");
 			if (rootProperty != null) {
 				var componentTypesDictionary = rootProperty.Value.ToObject<Dictionary<string, JObject>> ();
 				result.ComponentTypes = GetComponentTypes (componentTypesDictionary);
@@ -34,16 +34,15 @@ namespace Ardoq.Models.Converters
 		{
 			var result = new Dictionary<string, string> ();
 			foreach (var componentTypePair in componentTypesDictionary) {
-				JObject jObject = componentTypePair.Value;
-				JProperty nameProperty = jObject.Property ("name");
-				JProperty childrenProperty = jObject.Property ("children");
-				if (!result.ContainsKey (nameProperty.Value.ToObject<String> ())) {
-					result.Add (nameProperty.Value.ToObject<String> (), componentTypePair.Key);
+				var jObject = componentTypePair.Value;
+				var nameProperty = jObject.Property ("name");
+				var childrenProperty = jObject.Property ("children");
+				if (!result.ContainsKey (nameProperty.Value.ToObject<string> ())) {
+					result.Add (nameProperty.Value.ToObject<string> (), componentTypePair.Key);
 				} else {
-					Console.WriteLine ("Cannot properly parse model - Duplicate key: " + nameProperty.Value.ToObject<String> ());
+					Console.WriteLine ("Cannot properly parse model - Duplicate key: " + nameProperty.Value.ToObject<string> ());
 				}
-				Dictionary<string, string> subComponentTypes =
-					GetComponentTypes (childrenProperty.Value.ToObject<Dictionary<string, JObject>> ());
+				var subComponentTypes = GetComponentTypes (childrenProperty.Value.ToObject<Dictionary<string, JObject>> ());
 				foreach (var subComponentType in subComponentTypes) {
 					if (!result.ContainsKey (subComponentType.Key)) {
 						result.Add (subComponentType.Key, subComponentType.Value);
@@ -60,9 +59,9 @@ namespace Ardoq.Models.Converters
 			var result = new Dictionary<string, int> ();
 			if (null != referenceTypesDictionary) {
 				foreach (var referenceTypePair in referenceTypesDictionary) {
-					JObject jObject = referenceTypePair.Value;
-					JProperty nameProperty = jObject.Property ("name");
-					JProperty idProperty = jObject.Property ("id");
+					var jObject = referenceTypePair.Value;
+					var nameProperty = jObject.Property ("name");
+					var idProperty = jObject.Property ("id");
 					var key = nameProperty.Value.ToObject<string> ();
 					var value = idProperty.Value.ToObject<int> ();
 					if (result.ContainsKey (key)) {

--- a/Ardoq/Models/Model.cs
+++ b/Ardoq/Models/Model.cs
@@ -12,18 +12,18 @@ namespace Ardoq.Models
 		public DateTime? CreatedBy { get; set; }
 
 		[JsonProperty (PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
-		public String Name { get; set; }
+		public string Name { get; set; }
 
 		[JsonProperty (PropertyName = "description", NullValueHandling = NullValueHandling.Ignore)]
-		public String Description { get; set; }
+		public string Description { get; set; }
 
 		// TODO CHANGE THE DECLARATIONS OF THE MODEL CLASS TO REFLECT THE NEW MAP
 
 		[JsonIgnore]
-		public Dictionary<String, string> ComponentTypes { get; set; }
+		public Dictionary<string, string> ComponentTypes { get; set; }
 
 		[JsonIgnore]
-		public Dictionary<String, int> ReferenceTypes { get; set; }
+		public Dictionary<string, int> ReferenceTypes { get; set; }
 
 		#region ctor
 
@@ -86,14 +86,14 @@ namespace Ardoq.Models
 		public DateTime? LastUpdated { get; set; }
 
         [JsonProperty(PropertyName = "useAsTemplate", NullValueHandling = NullValueHandling.Ignore)]
-        public Boolean? UseAsTemplate { get; }
+        public bool? UseAsTemplate { get; set; }
 
         public int GetReferenceTypeByName (string name)
 		{
 			return ReferenceTypes [name];
 		}
 
-		public String GetComponentTypeByName (String name)
+		public string GetComponentTypeByName (string name)
 		{
 			return ComponentTypes [name];
 		}

--- a/Ardoq/Service/Interface/IDeprecatedModelService.cs
+++ b/Ardoq/Service/Interface/IDeprecatedModelService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ardoq.Models;
 using Refit;
@@ -18,11 +17,11 @@ namespace Ardoq.Service.Interface
 
         [Get ("/api/model/{id}")]
 		Task<Model> GetModelById(
-            [AliasAs ("id")] String id, 
+            [AliasAs ("id")] string id, 
             [AliasAs ("org")] string org = null);
 
-        Task<Model> GetTemplateByName(String name, string org = null);
+        Task<Model> GetTemplateByName(string name, string org = null);
 
-        Task<Model> UploadModel(String model, String org = null);
+        Task<Model> UploadModel(string model, string org = null);
     }
 }

--- a/Ardoq/Service/ModelService.cs
+++ b/Ardoq/Service/ModelService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -44,15 +44,15 @@ namespace Ardoq.Service
 		public async Task<Model> GetTemplateByName(string name, string org = null)
 		{
             org = org ?? Org;
-            var allModels = await Service.GetAllTemplates(org);
-			var result = allModels.Where (m => m.Name.ToLower () == name.ToLower ()).ToList ();
+            var allTemplates = await GetAllTemplates(org);
+			var result = allTemplates.Where (m => string.Equals(m.Name, name, StringComparison.OrdinalIgnoreCase)).ToList ();
 			if (!result.Any())
 				throw new InvalidOperationException ("No template with "+name+" name exists!");
 
 			return result.First();
 		}
 
-		public async Task<Model> UploadModel (String model, String org = null)
+		public async Task<Model> UploadModel (string model, string org = null)
 		{
             org = org ?? Org;
             const string urlTemplate = "api/model?org={0}";


### PR DESCRIPTION
UseAsTemplate did not have a setter in the Model class, thus causing
it to always be null.

Also changed GetTemplateByName to use the results from GetAllTemplates,
as opposed to duplicating the "is it a template"-check.