### PR TITLE
[Fix #10] Add GetTemplatesByName and GetModelsByName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,13 @@ TestResult.xml
 [Rr]eleasePS/
 dlldata.c
 
+# Jetbrains folder
+.idea/
+
 *_i.c
 *_p.c
 *_i.h
+*.iml
 *.ilk
 *.meta
 *.obj

--- a/Ardoq/Ardoq.nuspec
+++ b/Ardoq/Ardoq.nuspec
@@ -13,5 +13,6 @@
     <description>$description$</description>
     <copyright>Copyright 2017</copyright>
     <tags>Rest Api Ardoq</tags>
+    <releaseNotes>...</releaseNotes>
   </metadata>
 </package>

--- a/Ardoq/ArdoqClient.cs
+++ b/Ardoq/ArdoqClient.cs
@@ -10,166 +10,177 @@ using Refit;
 namespace Ardoq
 {
     public class ArdoqClient : IArdoqClient
-	{
-		private readonly HttpClient _httpClient;
-		private AttachmentService _attachmentService;
-		private ComponentService _componentService;
-		private FieldService _fieldService;
-		private ModelService _modelService;
+    {
+        private readonly HttpClient _httpClient;
+        private AttachmentService _attachmentService;
+        private ComponentService _componentService;
+        private FieldService _fieldService;
+        private ModelService _modelService;
         private ReferenceService _referenceService;
-		private TagService _tagService;
-		private FolderService _folderService;
-		private WorkspaceService _workspaceService;
-		private NotifyService _notifyService;
+        private TagService _tagService;
+        private FolderService _folderService;
+        private WorkspaceService _workspaceService;
+        private NotifyService _notifyService;
 
-		private ArdoqClient (HttpClient httpClient, string endPoint)
-		{
-			if (endPoint == null) {
-				throw new ArgumentNullException ("endPoint");
-			}
-			httpClient.BaseAddress = new Uri (endPoint);
-			httpClient.DefaultRequestHeaders.Add ("User-Agent", UserAgent);
-			_httpClient = httpClient;
-			EndPoint = endPoint;
-		}
-
-
-		public ArdoqClient (HttpClient httpClient, string endPoint, string token, string orgLabel) : this (httpClient, endPoint)
-		{
-			if (token == null) {
-				throw new ArgumentNullException ("Missing token");
-			}
-            if (orgLabel == null)
+        private ArdoqClient(HttpClient httpClient, string endPoint)
+        {
+            if (endPoint == null)
             {
-                throw new ArgumentNullException("Missing organization Label");
+                throw new ArgumentNullException(nameof(endPoint));
             }
 
-            Token = token;
-			Org = orgLabel;
-			AuthorizationValue = "Token token=" + Token.Trim ();
-			_httpClient.DefaultRequestHeaders.Add ("Authorization", AuthorizationValue);
-		}
-
-		public ArdoqClient (HttpClient httpClient, String endPoint, String username, String password, string orgLabel) : this (httpClient, endPoint)
-		{
-			if (username == null) {
-				throw new ArgumentNullException ("username");
-			}
-
-			if (password == null) {
-				throw new ArgumentNullException ("password");
-			}
-
-			Username = username;
-			Password = password;
-			Org = orgLabel;
-			AuthorizationValue = HeaderPassword;
-			_httpClient.DefaultRequestHeaders.Add ("Authorization", AuthorizationValue);
-		}
-
-		public static string ClientVersion {
-			get {
-				// TODO USE ASSEMBLY INFO. NOT SUPPORTED BY PORTABLE APIs
-				return "2.0.4";
-			}
-		}
-
-		public static string UserAgent {
-			get { return "ardoq-dotnet-client-" + ClientVersion; }
-		}
-
-		public String EndPoint { get; private set; }
-
-		public string Token { get; private set; }
-
-		public string Username { get; private set; }
-
-		public string Password { get; private set; }
-
-		public string Org { get; set; }
-
-		private string AuthorizationValue { get; set; }
-
-		private string HeaderPassword {
-			get {
-				string combinedPassword = Username + ":" + Password;
-				string hashedPassword = Convert.ToBase64String (Encoding.UTF8.GetBytes (combinedPassword));
-				string headerPassword = "Basic " + hashedPassword;
-				return headerPassword;
-			}
-		}
+            httpClient.BaseAddress = new Uri(endPoint);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+            _httpClient = httpClient;
+            EndPoint = endPoint;
+        }
 
 
-		public INotifyService NotifyService {
-			get {
-				return _notifyService ??
-				(_notifyService =
-						new NotifyService (RestService.For<INotifyService> (_httpClient), _httpClient));
-			}
-		}
+        public ArdoqClient(HttpClient httpClient, string endPoint, string token, string orgLabel) : this(httpClient,
+            endPoint)
+        {
+            Token = token ?? throw new ArgumentNullException("Missing token");
+            Org = orgLabel ?? throw new ArgumentNullException("Missing organization Label");
+            AuthorizationValue = "Token token=" + Token.Trim();
+            _httpClient.DefaultRequestHeaders.Add("Authorization", AuthorizationValue);
+        }
 
-		public IDeprecatedModelService ModelService {
-			get {
-				return _modelService ??
-				(_modelService =
-						new ModelService (RestService.For<IDeprecatedModelService> (_httpClient), _httpClient, Org));
-			}
-		}
+        public ArdoqClient(HttpClient httpClient, string endPoint, string username, string password, string orgLabel) :
+            this(httpClient, endPoint)
+        {
+            Username = username ?? throw new ArgumentNullException(nameof(username));
+            Password = password ?? throw new ArgumentNullException(nameof(password));
+            Org = orgLabel;
+            AuthorizationValue = HeaderPassword;
+            _httpClient.DefaultRequestHeaders.Add("Authorization", AuthorizationValue);
+        }
+
+        public static string ClientVersion
+        {
+            get
+            {
+                // TODO USE ASSEMBLY INFO. NOT SUPPORTED BY PORTABLE APIs
+                return "2.0.4";
+            }
+        }
+
+        public static string UserAgent
+        {
+            get { return "ardoq-dotnet-client-" + ClientVersion; }
+        }
+
+        public string EndPoint { get; private set; }
+
+        public string Token { get; private set; }
+
+        public string Username { get; private set; }
+
+        public string Password { get; private set; }
+
+        public string Org { get; set; }
+
+        private string AuthorizationValue { get; set; }
+
+        private string HeaderPassword
+        {
+            get
+            {
+                var combinedPassword = Username + ":" + Password;
+                var hashedPassword = Convert.ToBase64String(Encoding.UTF8.GetBytes(combinedPassword));
+                var headerPassword = "Basic " + hashedPassword;
+                return headerPassword;
+            }
+        }
 
 
-		public IAttachmentService AttachmentService {
-			get {
-				return _attachmentService ??
-				(_attachmentService =
-                           new AttachmentService (RestService.For<IAttachmentService> (_httpClient),
-					_httpClient, Org));
-			}
-		}
+        public INotifyService NotifyService
+        {
+            get
+            {
+                return _notifyService ??
+                       (_notifyService =
+                           new NotifyService(RestService.For<INotifyService>(_httpClient), _httpClient));
+            }
+        }
 
-		public IFieldService FieldService {
-			get {
-				return _fieldService ??
-				(_fieldService =
-                           new FieldService (RestService.For<IFieldService> (_httpClient), Org));
-			}
-		}
+        public IDeprecatedModelService ModelService
+        {
+            get
+            {
+                return _modelService ??
+                       (_modelService =
+                           new ModelService(RestService.For<IDeprecatedModelService>(_httpClient), _httpClient, Org));
+            }
+        }
 
-		public ITagService TagService {
-			get {
-				return _tagService ??
-				(_tagService = new TagService (RestService.For<ITagService> (_httpClient), Org));
-			}
-		}
 
-		public IFolderService FolderService {
-			get {
-				return _folderService ??
-				(_folderService = new FolderService (RestService.For<IFolderService> (_httpClient), Org));
-			}
-		}
+        public IAttachmentService AttachmentService
+        {
+            get
+            {
+                return _attachmentService ??
+                       (_attachmentService =
+                           new AttachmentService(RestService.For<IAttachmentService>(_httpClient),
+                               _httpClient, Org));
+            }
+        }
 
-		public IReferenceService ReferenceService {
-			get {
-				return _referenceService ??
-                (_referenceService =
-                           new ReferenceService (RestService.For<IReferenceService> (_httpClient), Org));
-			}
-		}
+        public IFieldService FieldService
+        {
+            get
+            {
+                return _fieldService ??
+                       (_fieldService =
+                           new FieldService(RestService.For<IFieldService>(_httpClient), Org));
+            }
+        }
 
-		public IComponentService ComponentService {
-			get {
-				return _componentService ??
-				(_componentService =
-                           new ComponentService (RestService.For<IComponentService> (_httpClient), Org));
-			}
-		}
+        public ITagService TagService
+        {
+            get
+            {
+                return _tagService ??
+                       (_tagService = new TagService(RestService.For<ITagService>(_httpClient), Org));
+            }
+        }
 
-		public IWorkspaceService WorkspaceService {
-			get {
-				return _workspaceService ??
-				(_workspaceService =
-                           new WorkspaceService (RestService.For<IWorkspaceService> (_httpClient), Org));
-			}
-		}
+        public IFolderService FolderService
+        {
+            get
+            {
+                return _folderService ??
+                       (_folderService = new FolderService(RestService.For<IFolderService>(_httpClient), Org));
+            }
+        }
+
+        public IReferenceService ReferenceService
+        {
+            get
+            {
+                return _referenceService ??
+                       (_referenceService =
+                           new ReferenceService(RestService.For<IReferenceService>(_httpClient), Org));
+            }
+        }
+
+        public IComponentService ComponentService
+        {
+            get
+            {
+                return _componentService ??
+                       (_componentService =
+                           new ComponentService(RestService.For<IComponentService>(_httpClient), Org));
+            }
+        }
+
+        public IWorkspaceService WorkspaceService
+        {
+            get
+            {
+                return _workspaceService ??
+                       (_workspaceService =
+                           new WorkspaceService(RestService.For<IWorkspaceService>(_httpClient), Org));
+            }
+        }
     }
 }

--- a/Ardoq/Properties/AssemblyInfo.cs
+++ b/Ardoq/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("2.0.4")]
+[assembly: AssemblyVersion("2.0.5")]
 [assembly: AssemblyFileVersion("1.0.0")]

--- a/Ardoq/Service/Interface/IDeprecatedModelService.cs
+++ b/Ardoq/Service/Interface/IDeprecatedModelService.cs
@@ -5,22 +5,26 @@ using Refit;
 
 namespace Ardoq.Service.Interface
 {
-	public interface IDeprecatedModelService
-	{
-		[Get ("/api/model")]
-		Task<List<Model>> GetAllModels(
-            [AliasAs ("org")] string org = null);
+    public interface IDeprecatedModelService
+    {
+        [Get("/api/model")]
+        Task<List<Model>> GetAllModels(
+            [AliasAs("org")] string org = null);
 
         [Get("/api/model?includeCommon=true")]
         Task<List<Model>> GetAllTemplates(
             [AliasAs("org")] string org = null);
 
-        [Get ("/api/model/{id}")]
-		Task<Model> GetModelById(
-            [AliasAs ("id")] string id, 
-            [AliasAs ("org")] string org = null);
+        [Get("/api/model/{id}")]
+        Task<Model> GetModelById(
+            [AliasAs("id")] string id,
+            [AliasAs("org")] string org = null);
+
+        Task<List<Model>> GetModelsByName(string name, string org = null);
 
         Task<Model> GetTemplateByName(string name, string org = null);
+
+        Task<List<Model>> GetTemplatesByName(string name, string org = null);
 
         Task<Model> UploadModel(string model, string org = null);
     }

--- a/Ardoq/Service/ModelService.cs
+++ b/Ardoq/Service/ModelService.cs
@@ -10,60 +10,76 @@ using System.Net.Http.Headers;
 
 namespace Ardoq.Service
 {
-	public class ModelService : ServiceBase, IDeprecatedModelService
+    public class ModelService : ServiceBase, IDeprecatedModelService
     {
-		internal ModelService (IDeprecatedModelService service, HttpClient sharedHttpClient, string org) : base (org)
-		{
-			Service = service;
-			HttpClient = sharedHttpClient;
-		}
+        internal ModelService(IDeprecatedModelService service, HttpClient sharedHttpClient, string org) : base(org)
+        {
+            Service = service;
+            HttpClient = sharedHttpClient;
+        }
 
-		private HttpClient HttpClient { get; set; }
+        private HttpClient HttpClient { get; set; }
 
-		private IDeprecatedModelService Service { get; set; }
+        private IDeprecatedModelService Service { get; set; }
 
-		public Task<List<Model>> GetAllModels (string org = null)
-		{
+        public Task<List<Model>> GetAllModels(string org = null)
+        {
             org = org ?? Org;
             return Service.GetAllModels(org);
-		}
+        }
 
         public async Task<List<Model>> GetAllTemplates(string org = null)
         {
             org = org ?? Org;
-            var allModels = await Service.GetAllTemplates(org);
-            return allModels.Where(m => m.UseAsTemplate == true).ToList();
+            return (
+                await Service.GetAllTemplates(org)
+            ).Where(m => m.UseAsTemplate == true).ToList();
         }
 
-        public Task<Model> GetModelById (string id, string org = null)
-		{
+        public Task<Model> GetModelById(string id, string org = null)
+        {
             org = org ?? Org;
             return Service.GetModelById(id, org);
-		}
+        }
 
-		public async Task<Model> GetTemplateByName(string name, string org = null)
-		{
+        public async Task<List<Model>> GetModelsByName(string name, string org = null)
+        {
+            org = org ?? Org;
+            return (
+                await GetAllModels(org)
+            ).Where(m => string.Equals(m.Name, name, StringComparison.OrdinalIgnoreCase)).ToList();
+        }
+
+        [Obsolete("GetTemplateByName only returns one of potentially several templates who share the same name. " +
+                  "Use GetTemplatesByName instead.")]
+        public async Task<Model> GetTemplateByName(string name, string org = null)
+        {
+            var result = await GetTemplatesByName(org);
+            if (!result.Any())
+                throw new InvalidOperationException("No template with " + name + " name exists!");
+
+            return result.First();
+        }
+
+        public async Task<List<Model>> GetTemplatesByName(string name, string org = null)
+        {
             org = org ?? Org;
             var allTemplates = await GetAllTemplates(org);
-			var result = allTemplates.Where (m => string.Equals(m.Name, name, StringComparison.OrdinalIgnoreCase)).ToList ();
-			if (!result.Any())
-				throw new InvalidOperationException ("No template with "+name+" name exists!");
+            return allTemplates.Where(m => string.Equals(m.Name, name, StringComparison.OrdinalIgnoreCase)).ToList();
+        }
 
-			return result.First();
-		}
-
-		public async Task<Model> UploadModel (string model, string org = null)
-		{
+        public async Task<Model> UploadModel(string model, string org = null)
+        {
             org = org ?? Org;
             const string urlTemplate = "api/model?org={0}";
-			var url = HttpClient.BaseAddress + string.Format (urlTemplate, org);
+            var url = HttpClient.BaseAddress + string.Format(urlTemplate, org);
 
-			var modelContent = new StringContent (model, System.Text.Encoding.UTF8);
-			modelContent.Headers.ContentType = MediaTypeHeaderValue.Parse ("application/json");
-			var responseMessage = await HttpClient.PostAsync (url, modelContent);
+            var modelContent = new StringContent(model, System.Text.Encoding.UTF8);
+            modelContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+            var responseMessage = await HttpClient.PostAsync(url, modelContent);
 
-			var attachmentJson = await responseMessage.Content.ReadAsStringAsync ();
-			return JsonConvert.DeserializeObject<Model> (attachmentJson);
-		}
-	}
+            var attachmentJson = await responseMessage.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<Model>(attachmentJson);
+        }
+    }
 }

--- a/ArdoqTests/Adapter/ComponentConverterTests.cs
+++ b/ArdoqTests/Adapter/ComponentConverterTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Ardoq.Models;
 using ArdoqTest.Helper;
 using Newtonsoft.Json;
@@ -15,9 +14,9 @@ namespace ArdoqTest.Adapter
         {
             var component = JsonConvert.DeserializeObject<Component>(TestUtils.LoadJsonFile("component.json"));
 
-            foreach (string s in new[] {"endpoint", "maintainer", "environment", "wsdl"})
+            foreach (var field in new[] {"endpoint", "maintainer", "environment", "wsdl"})
             {
-                Assert.True(component.Fields.ContainsKey(s));
+                Assert.True(component.Fields.ContainsKey(field));
             }
             Assert.True(component.Fields["maintainer"].ToString() == "erik@ardoq.com");
         }
@@ -27,7 +26,7 @@ namespace ArdoqTest.Adapter
         {
             var component = new Component("name", "rootWorkspace", "description", "typeId")
             {
-                Fields = new Dictionary<String, Object>
+                Fields = new Dictionary<string, object>
                 {
                     {"maintainer", "erik@ardoq.com"},
                     {"endpoint", "http://www.vg.no"}
@@ -36,7 +35,7 @@ namespace ArdoqTest.Adapter
             };
 
 
-            string s = JsonConvert.SerializeObject(component);
+            var s = JsonConvert.SerializeObject(component);
             var result = JsonConvert.DeserializeObject<Component>(s);
             Assert.True(result.Fields["maintainer"].ToString() == "erik@ardoq.com");
             Assert.True(result.Fields["endpoint"].ToString() == "http://www.vg.no");

--- a/ArdoqTests/Adapter/ModelConverterTests.cs
+++ b/ArdoqTests/Adapter/ModelConverterTests.cs
@@ -12,7 +12,7 @@ namespace ArdoqTest.Adapter
         [Test]
         public void DeserializeTest()
         {
-            string jsonObject = TestUtils.LoadJsonFile("model.json");
+            var jsonObject = TestUtils.LoadJsonFile("model.json");
             var result = JsonConvert.DeserializeObject<Model>(jsonObject);
             Assert.True(result.ReferenceTypes.Count == 5);
             Assert.True(2 == result.GetReferenceTypeByName("Implicit"));

--- a/ArdoqTests/Helper/LoggingHandler.cs
+++ b/ArdoqTests/Helper/LoggingHandler.cs
@@ -23,7 +23,7 @@ namespace ArdoqTest.Helper
             }
             Debug.WriteLine("");
 
-            HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken);
 
             Debug.WriteLine("Response:");
             Debug.WriteLine(response.ToString());

--- a/ArdoqTests/Helper/TestUtils.cs
+++ b/ArdoqTests/Helper/TestUtils.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -7,9 +6,9 @@ using System.Reflection;
 
 namespace ArdoqTest.Helper
 {
-    public class TestUtils
+    public static class TestUtils
     {
-        private static Dictionary<string, string> p;
+        private static Dictionary<string, string> _p;
 
         static TestUtils()
         {
@@ -23,8 +22,8 @@ namespace ArdoqTest.Helper
 
         private static void InitProperties()
         {
-            if (null != p) return;
-            p = new Dictionary<string, string>
+            if (null != _p) return;
+            _p = new Dictionary<string, string>
             {
                 {"organization", "jmeter"},
                 {"modelId", "555dc8b1e4b098e2e8379add"},
@@ -32,14 +31,14 @@ namespace ArdoqTest.Helper
             };
         }
 
-        public static String GetTestPropery(String name)
+        public static string GetTestProperty(string name)
         {
-            return p[name];
+            return _p[name];
         }
 
         public static string LoadJsonFile(string name)
         {
-            string path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"\TestData\json\" + name;
+            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"/TestData/json/" + name;
             return File.ReadAllText(path);
         }
     }

--- a/ArdoqTests/Helper/TestUtils.cs
+++ b/ArdoqTests/Helper/TestUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -38,7 +39,9 @@ namespace ArdoqTest.Helper
 
         public static string LoadJsonFile(string name)
         {
-            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"/TestData/json/" + name;
+            var basePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ??
+                           throw new Exception("Could not get base path");
+            var path = Path.Combine(basePath, "TestData", "json", name);
             return File.ReadAllText(path);
         }
     }

--- a/ArdoqTests/Models/ReferenceEqualityTest.cs
+++ b/ArdoqTests/Models/ReferenceEqualityTest.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace ArdoqTest.Models
 {
-    class ReferenceEqualityTest
+    internal class ReferenceEqualityTest
     {
         [Test]
         public void EqualityTest()

--- a/ArdoqTests/Service/AttachmentServiceTest.cs
+++ b/ArdoqTests/Service/AttachmentServiceTest.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Ardoq;
 using Ardoq.Models;
-using Ardoq.Service;
 using Ardoq.Service.Interface;
 using ArdoqTest.Helper;
 using NUnit.Framework;
@@ -16,53 +13,53 @@ namespace ArdoqTest.Service
     [TestFixture]
     public class AttachmentServiceTest
     {
-        private String filename;
-        private IArdoqClient client;
-        private IAttachmentService service;
+        private string _filename;
+        private IArdoqClient _client;
+        private IAttachmentService _service;
 
         [OneTimeSetUp]
         public void Setup()
         {
-            filename = TestUtils.GetTestPropery("filename");
-            client = TestUtils.GetClient();
+            _filename = TestUtils.GetTestProperty("filename");
+            _client = TestUtils.GetClient();
 
-            service = client.AttachmentService;
+            _service = _client.AttachmentService;
         }
 
         private async Task<Workspace> CreateWorkspace()
         {
             return
                 await
-                    client.WorkspaceService.CreateWorkspace(new Workspace("my Attachment Test Workspace",
-                        TestUtils.GetTestPropery("modelId"), "Hello world!"));
+                    _client.WorkspaceService.CreateWorkspace(new Workspace("my Attachment Test Workspace",
+                        TestUtils.GetTestProperty("modelId"), "Hello world!"));
         }
 
         private async Task DeleteWorkspace(Workspace workspace)
         {
-            await client.WorkspaceService.DeleteWorkspace(workspace.Id);
+            await _client.WorkspaceService.DeleteWorkspace(workspace.Id);
         }
 
         private async Task<Attachment> UploadAttachment(Workspace workspace)
         {
-            string path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"\TestData\Media\ardoq_hero.png";
-            FileStream stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return await service.UploadAttachment(workspace.Id, stream, filename);
+            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"/TestData/Media/ardoq_hero.png";
+            var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return await _service.UploadAttachment(workspace.Id, stream, _filename);
         }
 
         [Test]
         public async Task DeleteGetAttachmentsTest()
         {
-            Workspace workspace = await CreateWorkspace();
-            List<Attachment> attachments = await service.GetAttachments(workspace.Id);
+            var workspace = await CreateWorkspace();
+            var attachments = await _service.GetAttachments(workspace.Id);
             Assert.IsFalse(attachments.Any());
             await UploadAttachment(workspace);
-            attachments = await service.GetAttachments(workspace.Id);
-            foreach (Attachment attachment in attachments)
+            attachments = await _service.GetAttachments(workspace.Id);
+            foreach (var attachment in attachments)
             {
                 Assert.NotNull(attachment.Id);
             }
-            await service.DeleteAttachment(workspace.Id, filename);
-            List<Attachment> newList = await service.GetAttachments(workspace.Id);
+            await _service.DeleteAttachment(workspace.Id, _filename);
+            var newList = await _service.GetAttachments(workspace.Id);
             Assert.True(newList.Count == attachments.Count - 1);
             await DeleteWorkspace(workspace);
         }
@@ -70,9 +67,9 @@ namespace ArdoqTest.Service
         [Test]
         public async Task DownloadAttachmentTest()
         {
-            Workspace workspace = await CreateWorkspace();
-            Attachment attachment = await UploadAttachment(workspace);
-            Stream fileStream = await service.DownloadAttachment(workspace.Id, filename);
+            var workspace = await CreateWorkspace();
+            var attachment = await UploadAttachment(workspace);
+            var fileStream = await _service.DownloadAttachment(workspace.Id, _filename);
             Assert.True(fileStream.Length == attachment.Size);
             await DeleteWorkspace(workspace);
         }
@@ -80,9 +77,9 @@ namespace ArdoqTest.Service
         [Test]
         public async Task UploadAttachmentTest()
         {
-            Workspace workspace = await CreateWorkspace();
-            Attachment attachment = await UploadAttachment(workspace);
-            Assert.True(attachment.Filename == filename);
+            var workspace = await CreateWorkspace();
+            var attachment = await UploadAttachment(workspace);
+            Assert.True(attachment.Filename == _filename);
             await DeleteWorkspace(workspace);
         }
     }

--- a/ArdoqTests/Service/AttachmentServiceTest.cs
+++ b/ArdoqTests/Service/AttachmentServiceTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Ardoq;
@@ -41,7 +42,9 @@ namespace ArdoqTest.Service
 
         private async Task<Attachment> UploadAttachment(Workspace workspace)
         {
-            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"/TestData/Media/ardoq_hero.png";
+            var basePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ??
+                           throw new Exception("Could not get base path");
+            var path = Path.Combine(basePath, "TestData", "Media", "ardoq_hero.png");
             var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             return await _service.UploadAttachment(workspace.Id, stream, _filename);
         }
@@ -58,6 +61,7 @@ namespace ArdoqTest.Service
             {
                 Assert.NotNull(attachment.Id);
             }
+
             await _service.DeleteAttachment(workspace.Id, _filename);
             var newList = await _service.GetAttachments(workspace.Id);
             Assert.True(newList.Count == attachments.Count - 1);

--- a/ArdoqTests/Service/ComponentServiceTests.cs
+++ b/ArdoqTests/Service/ComponentServiceTests.cs
@@ -1,9 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Ardoq;
 using Ardoq.Models;
-using Ardoq.Service;
 using Ardoq.Service.Interface;
 using ArdoqTest.Helper;
 using NUnit.Framework;
@@ -14,23 +11,23 @@ namespace ArdoqTest.Service
     [TestFixture]
     public class ComponentServiceTests
     {
-        private IComponentService service;
-        private IArdoqClient client;
+        private IComponentService _service;
+        private IArdoqClient _client;
 
         [OneTimeSetUp]
         public void Setup()
         {
-            client = TestUtils.GetClient();
-            service = client.ComponentService;
+            _client = TestUtils.GetClient();
+            _service = _client.ComponentService;
         }
 
         private async Task<Workspace> CreateWorkspace()
         {
-            Workspace workspace =
+            var workspace =
                 await
-                    client.WorkspaceService.CreateWorkspace(
+                    _client.WorkspaceService.CreateWorkspace(
                         new Workspace("My Component Test Workspace",
-                        TestUtils.GetTestPropery("modelId"), "Hello world!"));
+                        TestUtils.GetTestProperty("modelId"), "Hello world!"));
             return workspace;
         }
 
@@ -41,35 +38,35 @@ namespace ArdoqTest.Service
 
         private async Task DeleteWorkspace(Workspace workspace)
         {
-            await client.WorkspaceService.DeleteWorkspace(workspace.Id);
+            await _client.WorkspaceService.DeleteWorkspace(workspace.Id);
         }
 
         [Test]
         public async Task CreateComponentTest()
         {
-            Workspace workspace = await CreateWorkspace();
-            Component componentTemplate = CreateComponentTemplate(workspace);
-            Component component = await service.CreateComponent(componentTemplate);
+            var workspace = await CreateWorkspace();
+            var componentTemplate = CreateComponentTemplate(workspace);
+            var component = await _service.CreateComponent(componentTemplate);
             Assert.NotNull(component.Id);
-            await service.DeleteComponent(component.Id);
+            await _service.DeleteComponent(component.Id);
             await DeleteWorkspace(workspace);
         }
 
         [Test]
         public async Task DeleteComponentTest()
         {
-            Workspace workspace = await CreateWorkspace();
-            Component componentTemplate = CreateComponentTemplate(workspace);
-            Component result = await service.CreateComponent(componentTemplate);
+            var workspace = await CreateWorkspace();
+            var componentTemplate = CreateComponentTemplate(workspace);
+            var result = await _service.CreateComponent(componentTemplate);
             Assert.NotNull(result.Id);
-            await service.DeleteComponent(result.Id);
+            await _service.DeleteComponent(result.Id);
             try
             {
-                await service.GetComponentById(result.Id);
+                await _service.GetComponentById(result.Id);
                 await DeleteWorkspace(workspace);
                 Assert.Fail("Expected the Component to be deleted.");
             }
-            catch (Refit.ApiException e)
+            catch (ApiException e)
             {
                 Assert.AreEqual(System.Net.HttpStatusCode.NotFound, e.StatusCode);
             }
@@ -79,28 +76,28 @@ namespace ArdoqTest.Service
         [Test]
         public async Task GetComponentTest()
         {
-            Workspace workspace = await CreateWorkspace();
-            Component componentTemplate = CreateComponentTemplate(workspace);
-            Component component = await service.CreateComponent(componentTemplate);
-            List<Component> allComponents = await service.GetAllComponents();
-            string id = allComponents[0].Id;
-            Component expectedComponent = await service.GetComponentById(id);
+            var workspace = await CreateWorkspace();
+            var componentTemplate = CreateComponentTemplate(workspace);
+            var component = await _service.CreateComponent(componentTemplate);
+            var allComponents = await _service.GetAllComponents();
+            var id = allComponents[0].Id;
+            var expectedComponent = await _service.GetComponentById(id);
             Assert.True(id == expectedComponent.Id);
-            await service.DeleteComponent(component.Id);
+            await _service.DeleteComponent(component.Id);
             await DeleteWorkspace(workspace);
         }
 
         [Test]
         public async Task UpdateComponentTest()
         {
-            Workspace workspace = await CreateWorkspace();
-            Component componentTemplate = CreateComponentTemplate(workspace);
-            Component component = await service.CreateComponent(componentTemplate);
+            var workspace = await CreateWorkspace();
+            var componentTemplate = CreateComponentTemplate(workspace);
+            var component = await _service.CreateComponent(componentTemplate);
             component.Description = "Updated description";
-            Component updatedComponent = await service.UpdateComponent(component.Id, component);
+            var updatedComponent = await _service.UpdateComponent(component.Id, component);
             Assert.True("Updated description" == updatedComponent.Description);
             Assert.True(component.VersionCounter == updatedComponent.VersionCounter - 1);
-            await service.DeleteComponent(component.Id);
+            await _service.DeleteComponent(component.Id);
             await DeleteWorkspace(workspace);
         }
     }

--- a/ArdoqTests/Service/FieldServiceTests.cs
+++ b/ArdoqTests/Service/FieldServiceTests.cs
@@ -22,7 +22,7 @@ namespace ArdoqTest.Service
         public void Setup()
         {
             client = TestUtils.GetClient();
-            modelId = TestUtils.GetTestPropery("modelId");
+            modelId = TestUtils.GetTestProperty("modelId");
             service = client.FieldService;
         }
 

--- a/ArdoqTests/Service/ModelServiceTest.cs
+++ b/ArdoqTests/Service/ModelServiceTest.cs
@@ -1,51 +1,49 @@
-﻿using System;
+﻿using System.Linq;
 using Ardoq;
-using Ardoq.Models;
 using Ardoq.Service.Interface;
 using ArdoqTest.Helper;
 using NUnit.Framework;
 using System.Threading.Tasks;
-using System.Collections.Generic;
 
 namespace ArdoqTest.Service
 {
     [TestFixture]
     public class ModelServiceTest
     {
-        private IDeprecatedModelService service;
-        private String modelId;
-        private IArdoqClient client;
+        private IDeprecatedModelService _service;
+        private string _modelId;
+        private IArdoqClient _client;
 
         [OneTimeSetUp]
         public void Setup()
         {
-            client = TestUtils.GetClient();
-            service = client.ModelService;
-            modelId = TestUtils.GetTestPropery("modelId");
+            _client = TestUtils.GetClient();
+            _service = _client.ModelService;
+            _modelId = TestUtils.GetTestProperty("modelId");
         }
 
         [Test]
-        public async Task GetModelByNameTest()
+        public async Task GetTemplatesByNameTest()
         {
-            Model modelById = await service.GetModelById(modelId);
-            Model modelByName = await service.GetTemplateByName(modelById.Name);
-            Assert.True(modelById.Id == modelByName.Id);
+            var modelById = await _service.GetModelById(_modelId);
+            var modelsByName = await _service.GetModelsByName(modelById.Name);
+            Assert.Contains(modelById.Id, modelsByName.Select(model => model.Id).ToList());
         }
 
         [Test]
         public async Task GetTemplateByNameTest()
         {
-            Model modelByName = await service.GetTemplateByName("Application Service");
-            Assert.True(modelByName.Name == "Application Service");
+            var modelByName = await _service.GetTemplateByName("Application Service");
+            Assert.AreEqual(modelByName.Name, "Application Service");
         }
 
         [Test]
         public async Task GetAllTemplatesTest()
         {
-            List<Model> allTemplates = await service.GetAllTemplates();
-            List<Model> allModels = await service.GetAllModels();
-            allTemplates.TrueForAll(m => m.UseAsTemplate == true);
-            Assert.True(allModels.Count > allTemplates.Count);
+            var allTemplates = await _service.GetAllTemplates();
+            var allModels = await _service.GetAllModels();
+            Assert.True(allTemplates.TrueForAll(m => m.UseAsTemplate == true));
+            Assert.Greater(allModels.Count, allTemplates.Count);
         }
     }
 }

--- a/ArdoqTests/Service/ReferenceServiceTest.cs
+++ b/ArdoqTests/Service/ReferenceServiceTest.cs
@@ -31,7 +31,7 @@ namespace ArdoqTest.Service
             return
                 await
                     client.WorkspaceService.CreateWorkspace(new Workspace("Reference Test Workspace",
-                        TestUtils.GetTestPropery("modelId"), "Hello world!"));
+                        TestUtils.GetTestProperty("modelId"), "Hello world!"));
         }
 
         private async Task<Component> CreateComponent(Workspace workspace, string name)

--- a/ArdoqTests/Service/TagServiceTest.cs
+++ b/ArdoqTests/Service/TagServiceTest.cs
@@ -21,7 +21,7 @@ namespace ArdoqTest.Service
         public void Setup()
         {
             client = TestUtils.GetClient();
-            workspaceTemplate = new Workspace("Test Workspace", TestUtils.GetTestPropery("modelId"), "Hello world!");
+            workspaceTemplate = new Workspace("Test Workspace", TestUtils.GetTestProperty("modelId"), "Hello world!");
             tagService = client.TagService;
         }
 

--- a/ArdoqTests/Service/WorkspaceServiceTest.cs
+++ b/ArdoqTests/Service/WorkspaceServiceTest.cs
@@ -27,7 +27,7 @@ namespace ArdoqTest.Service
 
         private static Workspace CreateWorkspaceTemplate()
         {
-            return new Workspace("Test Workspace", TestUtils.GetTestPropery("modelId"), "Hello world!");
+            return new Workspace("Test Workspace", TestUtils.GetTestProperty("modelId"), "Hello world!");
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace ArdoqTest.Service
         [Test]
         public async Task GetAggregatedWorkspaceTest()
         {
-            var workspace = new Workspace("Test Workspace", TestUtils.GetTestPropery("modelId"), "Hello world!");
+            var workspace = new Workspace("Test Workspace", TestUtils.GetTestProperty("modelId"), "Hello world!");
 
             Workspace aggregatedWorkspace = await service.CreateWorkspace(workspace);
 

--- a/ArdoqTests/TestData/json/component.json
+++ b/ArdoqTests/TestData/json/component.json
@@ -1,1 +1,24 @@
-{"maintainer": "erik@ardoq.com", "description": "", "last-updated": "2014-04-07T09:13:59.662+02:00", "_id": "53424fc63004ad61cd5fe092", "children": [], "parent": "53424e673004ad61cd5fe084", "name": "Test", "value": 0, "type": "Service", "created": "2014-04-07T09:12:06.323+02:00", "rootWorkspace": "533f9ea33004ad61cd5fe071", "state": "new", "typeId": "p1375510381383", "wsdl": "http:\/\/test.foo.bar", "isPublic": false, "created-by": "520383b8e4b0836fe8d5ee62", "environment": "PT,ST,AT,PROD", "version": "0.0.1", "_version": 11, "endpoint": "http:\/\/www.vg.no", "targetValue": null, "model": "53304764e4b029076f313cd2"}
+{
+  "maintainer": "erik@ardoq.com",
+  "description": "",
+  "last-updated": "2014-04-07T09:13:59.662+02:00",
+  "_id": "53424fc63004ad61cd5fe092",
+  "children": [],
+  "parent": "53424e673004ad61cd5fe084",
+  "name": "Test",
+  "value": 0,
+  "type": "Service",
+  "created": "2014-04-07T09:12:06.323+02:00",
+  "rootWorkspace": "533f9ea33004ad61cd5fe071",
+  "state": "new",
+  "typeId": "p1375510381383",
+  "wsdl": "http:\/\/test.foo.bar",
+  "isPublic": false,
+  "created-by": "520383b8e4b0836fe8d5ee62",
+  "environment": "PT,ST,AT,PROD",
+  "version": "0.0.1",
+  "_version": 11,
+  "endpoint": "http:\/\/www.vg.no",
+  "targetValue": null,
+  "model": "53304764e4b029076f313cd2"
+}

--- a/ArdoqTests/TestData/json/model.json
+++ b/ArdoqTests/TestData/json/model.json
@@ -1,96 +1,114 @@
-{"_id": "52fc9b95e4b0b737f290103b", "_version": 1, "created-by": "520383b8e4b0836fe8d5ee62", "last-updated": "2014-02-13T10:16:53.015Z", "created": "2014-02-13T10:16:53.015Z", "name": "Simple EA Model", "description": "", "root": {
+{
+  "_id": "52fc9b95e4b0b737f290103b",
+  "_version": 1,
+  "created-by": "520383b8e4b0836fe8d5ee62",
+  "last-updated": "2014-02-13T10:16:53.015Z",
+  "created": "2014-02-13T10:16:53.015Z",
+  "name": "Simple EA Model",
+  "description": "",
+  "root": {
     "p1392286564116": {
-        "name": "Department",
-        "canLinkTo": null,
-        "description": "description",
-        "level": 1,
-        "returnsValue": false,
-        "children": {
-            "p1392286571342": {
-                "name": "System",
-                "canLinkTo": ["p1392286584766", "p1392286589698"],
-                "description": "description",
-                "level": 2,
-                "returnsValue": false,
-                "children": {
-                    "p1392286584766": {
-                        "name": "Application",
-                        "canLinkTo": ["p1392286584766", "p1392286589698"],
-                        "description": "description",
-                        "level": 3,
-                        "returnsValue": false,
-                        "children": {
-                            "p1392286589698": {
-                                "name": "Service",
-                                "canLinkTo": ["p1392286589698"],
-                                "description": "description",
-                                "level": 4,
-                                "returnsValue": false,
-                                "children": {},
-                                "id": "p1392286589698",
-                                "index": 1
-                            }
-                        },
-                        "id": "p1392286584766",
-                        "index": 1
-                    }
-                },
-                "id": "p1392286571342",
-                "index": 1
+      "name": "Department",
+      "canLinkTo": null,
+      "description": "description",
+      "level": 1,
+      "returnsValue": false,
+      "children": {
+        "p1392286571342": {
+          "name": "System",
+          "canLinkTo": [
+            "p1392286584766",
+            "p1392286589698"
+          ],
+          "description": "description",
+          "level": 2,
+          "returnsValue": false,
+          "children": {
+            "p1392286584766": {
+              "name": "Application",
+              "canLinkTo": [
+                "p1392286584766",
+                "p1392286589698"
+              ],
+              "description": "description",
+              "level": 3,
+              "returnsValue": false,
+              "children": {
+                "p1392286589698": {
+                  "name": "Service",
+                  "canLinkTo": [
+                    "p1392286589698"
+                  ],
+                  "description": "description",
+                  "level": 4,
+                  "returnsValue": false,
+                  "children": {},
+                  "id": "p1392286589698",
+                  "index": 1
+                }
+              },
+              "id": "p1392286584766",
+              "index": 1
             }
-        },
-        "id": "p1392286564116",
-        "index": 1
+          },
+          "id": "p1392286571342",
+          "index": 1
+        }
+      },
+      "id": "p1392286564116",
+      "index": 1
     }
-}, "referenceTypes": {
+  },
+  "referenceTypes": {
     "0": {
-        "name": "Asynchronous",
-        "id": 0,
-        "line": "dotted",
-        "color": "blue",
-        "lineEnding": "bottom",
-        "returnsValue": true,
-        "charLine": "=",
-        "svgStyle": "stroke: blue;stroke-dasharray:2"
+      "name": "Asynchronous",
+      "id": 0,
+      "line": "dotted",
+      "color": "blue",
+      "lineEnding": "bottom",
+      "returnsValue": true,
+      "charLine": "=",
+      "svgStyle": "stroke: blue;stroke-dasharray:2"
     },
     "1": {
-        "name": "Synchronous",
-        "id": 1,
-        "line": "solid",
-        "color": "black",
-        "lineEnding": "both",
-        "returnsValue": true,
-        "charLine": "-",
-        "svgStyle": "stroke: black;"
+      "name": "Synchronous",
+      "id": 1,
+      "line": "solid",
+      "color": "black",
+      "lineEnding": "both",
+      "returnsValue": true,
+      "charLine": "-",
+      "svgStyle": "stroke: black;"
     },
     "2": {
-        "name": "Implicit",
-        "id": 2,
-        "line": "dashed",
-        "color": "red",
-        "lineEnding": "none",
-        "returnsValue": false,
-        "charLine": "_",
-        "svgStyle": "stroke: red;stroke-dasharray:10,5"
+      "name": "Implicit",
+      "id": 2,
+      "line": "dashed",
+      "color": "red",
+      "lineEnding": "none",
+      "returnsValue": false,
+      "charLine": "_",
+      "svgStyle": "stroke: red;stroke-dasharray:10,5"
     },
     "3": {
-        "name": "Fire and forget",
-        "id": 3,
-        "line": "dotted",
-        "color": "orange",
-        "lineEnding": "both",
-        "returnsValue": false,
-        "charLine": "+",
-        "svgStyle": "stroke: orange;stroke-dasharray:2"
+      "name": "Fire and forget",
+      "id": 3,
+      "line": "dotted",
+      "color": "orange",
+      "lineEnding": "both",
+      "returnsValue": false,
+      "charLine": "+",
+      "svgStyle": "stroke: orange;stroke-dasharray:2"
     },
     "4": {
-        "name": "Data flow",
-        "id": 4,
-        "line": "solid",
-        "color": "gray",
-        "lineEnding": "circle",
-        "returnsValue": false,
-        "charLine": "?",
-        "svgStyle": "stroke: gray;"
+      "name": "Data flow",
+      "id": 4,
+      "line": "solid",
+      "color": "gray",
+      "lineEnding": "circle",
+      "returnsValue": false,
+      "charLine": "?",
+      "svgStyle": "stroke: gray;"
     }
-}}
+  }
+}


### PR DESCRIPTION
The old helper-function "GetTemplateByName" only returned one element
or an exception. Deprecate this function and instead add functions that
return a list of models/templates.