### PR TITLE
Change type of Model.CreatedBy to string

### DIFF
--- a/Ardoq/Models/Model.cs
+++ b/Ardoq/Models/Model.cs
@@ -9,7 +9,7 @@ namespace Ardoq.Models
 	public class Model : IModel
 	{
 		[JsonProperty (PropertyName = "createdBy", NullValueHandling = NullValueHandling.Ignore)]
-		public DateTime? CreatedBy { get; set; }
+		public string CreatedBy { get; set; }
 
 		[JsonProperty (PropertyName = "name", NullValueHandling = NullValueHandling.Ignore)]
 		public string Name { get; set; }


### PR DESCRIPTION
Since the API started returning an ID for this field, an exeption was
thrown when trying to deserialize the value to a nullable DateTime.

Fixes #13